### PR TITLE
네비게이션 뷰 이동 한 후, 필터 버튼 작동 안하는 문제 해결

### DIFF
--- a/UDD/Presentation/Main/View/Home/HomeViewController.swift
+++ b/UDD/Presentation/Main/View/Home/HomeViewController.swift
@@ -27,6 +27,12 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
         addDummy1()
         addDummy2()
         addDummy3()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.setNavigationBarHidden(true, animated: true)
 
         NotificationCenter.default.addObserver(
             self,
@@ -34,12 +40,6 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITableViewData
             name: NSNotification.Name(rawValue: "refresh"),
             object: nil
         )
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        navigationController?.setNavigationBarHidden(true, animated: true)
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
## 작업사항

<!--- 작업 사항들의 간단한 설명들을 작성해주세요 -->
네비게이션 뷰 이동 시 메인뷰가 disappear 되면서 notification을 remove 하고 다시 appear 하면서 add를 하지 않는 이슈
메인뷰의 willappear으로 notification add를 옮겨서 해결

## 이슈 번호

<!-- 이슈 번호를 연결해주세요 -->
네비게이션 뷰 이동 한 후, 필터 버튼 작동 안하는 문제 #74

## 특이사항 (optional)

<!--- 특이 사항이 있으시면 작성해주세요 -->